### PR TITLE
okhttp3 websocket send buffer full로 인해 정상적으로 샘플이 동작하지 않는 문제 수정.

### DIFF
--- a/src/main/java/ai/vito/openapi/stream/VitoSttWebSocketClient.java
+++ b/src/main/java/ai/vito/openapi/stream/VitoSttWebSocketClient.java
@@ -3,6 +3,7 @@ package ai.vito.openapi.stream;
 import java.io.File;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.concurrent.CountDownLatch;
 
 import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.AudioSystem;
@@ -17,52 +18,62 @@ import okhttp3.WebSocketListener;
 import okio.ByteString;
 
 public class VitoSttWebSocketClient {
-	
-	public static void main(String[] args) throws Exception {
-		OkHttpClient client = new OkHttpClient();
 
-		String token = Auth.getAccessToken();
-		
-		HttpUrl.Builder httpBuilder = HttpUrl.get("https://openapi.vito.ai/v1/transcribe:streaming").newBuilder();
-	    httpBuilder.addQueryParameter("sample_rate","8000");
-	    httpBuilder.addQueryParameter("encoding","LINEAR16");
-	    httpBuilder.addQueryParameter("use_itn","true");
-	    httpBuilder.addQueryParameter("use_disfluency_filter","true");
-	    httpBuilder.addQueryParameter("use_profanity_filter","true");
-		
-	    String url = httpBuilder.toString().replace("https://", "wss://");
+    public static void main(String[] args) throws Exception {
+        Logger logger = Logger.getLogger(VitoSttWebSocketClient.class.getName());
+        OkHttpClient client = new OkHttpClient();
+
+        String token = Auth.getAccessToken();
+
+        HttpUrl.Builder httpBuilder = HttpUrl.get("https://openapi.vito.ai/v1/transcribe:streaming").newBuilder();
+        httpBuilder.addQueryParameter("sample_rate", "8000");
+        httpBuilder.addQueryParameter("encoding", "LINEAR16");
+        httpBuilder.addQueryParameter("use_itn", "true");
+        httpBuilder.addQueryParameter("use_disfluency_filter", "true");
+        httpBuilder.addQueryParameter("use_profanity_filter", "true");
+
+        String url = httpBuilder.toString().replace("https://", "wss://");
 
         Request request = new Request.Builder()
                 .url(url)
-                .addHeader("Authorization","Bearer "+token)
+                .addHeader("Authorization", "Bearer " + token)
                 .build();
 
         VitoWebSocketListener webSocketListener = new VitoWebSocketListener();
         WebSocket vitoWebSocket = client.newWebSocket(request, webSocketListener);
-        
+
         File file = new File("sample.wav");
-		AudioInputStream in = AudioSystem.getAudioInputStream(file);
-		
+        AudioInputStream in = AudioSystem.getAudioInputStream(file);
+
         byte[] buffer = new byte[1024];
-        while (in.read(buffer) != -1) {
-        	vitoWebSocket.send(ByteString.of(buffer));
+        int readBytes;
+        while ((readBytes = in.read(buffer)) != -1) {
+            boolean sent = vitoWebSocket.send(ByteString.of(buffer, 0, readBytes));
+            if (!sent) {
+                logger.log(Level.WARNING, "Send buffer is full. Cannot complete request. Increase sleep interval.");
+                System.exit(1);
+            }
+            Thread.sleep(0, 50);
         }
-        
+        vitoWebSocket.send("EOS");
+
+        webSocketListener.waitClose();
         client.dispatcher().executorService().shutdown();
-	}
+    }
 }
 
 class VitoWebSocketListener extends WebSocketListener {
-	private static final Logger logger = Logger.getLogger(VitoSttGrpcClient.class.getName());
-	private static final int NORMAL_CLOSURE_STATUS = 1000;
-	
-	private static void log(Level level, String msg, Object... args) {
+    private static final Logger logger = Logger.getLogger(VitoSttWebSocketClient.class.getName());
+    private static final int NORMAL_CLOSURE_STATUS = 1000;
+    private final CountDownLatch latch = new CountDownLatch(1);
+
+    private static void log(Level level, String msg, Object... args) {
         logger.log(level, msg, args);
     }
 
     @Override
     public void onOpen(WebSocket webSocket, Response response) {
-    	log(Level.INFO, "Open " + response.message());
+        log(Level.INFO, "Open " + response.message());
     }
 
     @Override
@@ -72,19 +83,30 @@ class VitoWebSocketListener extends WebSocketListener {
 
     @Override
     public void onMessage(WebSocket webSocket, ByteString bytes) {
-    	System.out.println(bytes.hex());
+        System.out.println(bytes.hex());
     }
 
     @Override
     public void onClosing(WebSocket webSocket, int code, String reason) {
         webSocket.close(NORMAL_CLOSURE_STATUS, null);
-        log(Level.INFO, "Closing", code, reason);
+        log(Level.INFO, "Closing {0} {1}", code, reason);
+    }
+
+    @Override
+    public void onClosed(WebSocket webSocket, int code, String reason) {
+        webSocket.close(NORMAL_CLOSURE_STATUS, null);
+        log(Level.INFO, "Closed {0} {1}", code, reason);
+        latch.countDown();
     }
 
     @Override
     public void onFailure(WebSocket webSocket, Throwable t, Response response) {
         t.printStackTrace();
-        
+        latch.countDown();
     }
-	
+
+    public void waitClose() throws InterruptedException {
+        log(Level.INFO, "Wait for finish");
+        latch.await();
+    }
 }


### PR DESCRIPTION
okhttp3의 send buffer는 16MiB입니다.
websocket전송시 send buffer가 가득찼을때 다시 send를 호출하는경우 경우 1001 (going away) 코드와 함께 접속을 끊어버립니다.

용량이 조금 큰 파일을 딜레이 없이 읽어서 전송할 경우 실패합니다.

실시간 STT 예제이기 때문에 일반적인 실시간 상황에서는 발생하지 않습니다.
파일을 전사할 경우에는 일반 STT로 안내를 해야합니다.

샘플에서 전사가 완료되기전에 끝나버리는 경우(Close 1001)에는 Thread.sleep의 값을 늘려주면 동작합니다.